### PR TITLE
Change cow circle radii

### DIFF
--- a/src/battlecode/client/viewer/render/DrawMap.as
+++ b/src/battlecode/client/viewer/render/DrawMap.as
@@ -150,7 +150,7 @@
                     var color:Number = Team.cowColor(Team.valueOf(cowsTeams[i][j]));
                     this.neutralCanvas.graphics.lineStyle(1, color, 0.8);
                     this.neutralCanvas.graphics.beginFill(color, 0.4);
-                    this.neutralCanvas.graphics.drawCircle((i + .5) * g, (j + .5) * g, g * density / 2);
+                    this.neutralCanvas.graphics.drawCircle((i + .5) * g, (j + .5) * g, g * Math.sqrt(density) / 2);
                     this.neutralCanvas.graphics.endFill();
                 }
             }


### PR DESCRIPTION
This changes cow circle radii from being proportional to the number of
cows in a square to being proportional to the square root of the
number of cows in a square.  Since the circle area is proportional to
the square of the radius, this makes the area of circles proportional
to the number of cows, instead of the square of the number of cows.
